### PR TITLE
fix: fixed dry run (closes #3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,17 +3,7 @@
   "description": "Lightweight util.format() for the browser.",
   "version": "1.0.3",
   "author": "muji <noop@xpm.io>",
-  "license": "MIT",
   "browser": "./format.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tmpfs/format-util.git"
-  },
-  "keywords": [
-    "util",
-    "format",
-    "string"
-  ],
   "devDependencies": {
     "browserify": "~11.1.0",
     "chai": "~3.2.0",
@@ -21,17 +11,16 @@
     "istanbul": "~0.3.17",
     "mocha": "~2.3.2"
   },
-  "scripts": {
-    "lint": "jshint . && jscs .",
-    "docs": "npm run readme",
-    "readme": "mdp --force -v",
-    "browserify": "browserify -o format-util.js -e ./format.js && du -bh format-util.js",
-    "clean": "rm -rf coverage ./format-util.js ./test/spec.js",
-    "spec": "browserify -o test/spec.js -e test/index.js",
-    "test": "NODE_ENV=test mocha ${SPEC:-test/spec}",
-    "cover": "NODE_ENV=test istanbul cover _mocha -- ${SPEC:-test/spec}",
-    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
-  },
+  "files": [
+    "index.js",
+    "format.js"
+  ],
+  "keywords": [
+    "format",
+    "string",
+    "util"
+  ],
+  "license": "MIT",
   "mdp": {
     "title": "Format Util",
     "pedantic": true,
@@ -51,5 +40,20 @@
         ]
       }
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tmpfs/format-util.git"
+  },
+  "scripts": {
+    "browserify": "browserify -o format-util.js -e ./format.js && du -bh format-util.js",
+    "clean": "rm -rf coverage ./format-util.js ./test/spec.js",
+    "cover": "NODE_ENV=test istanbul cover _mocha -- ${SPEC:-test/spec}",
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "docs": "npm run readme",
+    "lint": "jshint . && jscs .",
+    "readme": "mdp --force -v",
+    "spec": "browserify -o test/spec.js -e test/index.js",
+    "test": "NODE_ENV=test mocha ${SPEC:-test/spec}"
   }
 }


### PR DESCRIPTION
```sh
npm publish --dry-run
npm notice
npm notice 📦  format-util@1.0.3
npm notice === Tarball Contents ===
npm notice 2.7kB LICENSE
npm notice 804B  format.js
npm notice 41B   index.js
npm notice 1.5kB package.json
npm notice 2.1kB README.md
npm notice === Tarball Details ===
npm notice name:          format-util
npm notice version:       1.0.3
npm notice package size:  3.2 kB
npm notice unpacked size: 7.1 kB
npm notice shasum:        c77e1c7f5d02e4a816ff478c16ea65d155225098
npm notice integrity:     sha512-jVFs+pCKu2eOv[...]xVUf2JplAtZog==
npm notice total files:   5
npm notice
+ format-util@1.0.3
```